### PR TITLE
Biraj/eng 647 bug update voices in swift sdk

### DIFF
--- a/BasicVoiceBot/BasicVoiceBot/ContentView.swift
+++ b/BasicVoiceBot/BasicVoiceBot/ContentView.swift
@@ -146,7 +146,7 @@ struct ContentView: View {
             // Connection status indicator
             Circle()
                 .frame(width: 12, height: 12)
-                .contentTransition(.numericText())
+                // .contentTransition(.numericText())  // needs iOS 16+
                 .animation(.easeInOut(duration: 0.3), value: connectionStatus)
                 .onChange(of: connectionStatus) { _ in
                     switch connectionStatus {
@@ -223,7 +223,7 @@ struct ContentView: View {
                 .padding(.top, 4)
             Text(msg.text.trimmingCharacters(in: .whitespacesAndNewlines))
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .contentTransition(.numericText())
+                // .contentTransition(.numericText())  // needs iOS 16+
                 .animation(.easeInOut(duration: 0.1), value: msg.text)
         }
         .contextMenu {
@@ -238,7 +238,7 @@ struct ContentView: View {
     @ViewBuilder
     private func MessageInputView() -> some View {
         HStack {
-            TextField("Insert message...", text: $outgoingMessage, axis: .vertical)
+            TextField("Insert message...", text: $outgoingMessage)
                 .textFieldStyle(.roundedBorder)
                 .focused($isTextFieldFocused)
                 .onChange(of: outgoingMessage) { newValue in

--- a/BasicVoiceBot/BasicVoiceBot/ContentView.swift
+++ b/BasicVoiceBot/BasicVoiceBot/ContentView.swift
@@ -96,8 +96,8 @@ struct ContentView: View {
 
                 // Configure voice selection (ElevenLabs compatible)
                 let ttsConfig = OutspeedSDK.TTSConfig(voiceId: selectedVoice)
-                // example usage of OrpheusVoice enum
-                // let ttsConfig = OutspeedSDK.TTSConfig(voiceId: OutspeedSDK.OrpheusVoice.zac.rawValue)
+                // example usage of Voice enum
+                // let ttsConfig = OutspeedSDK.TTSConfig(voiceId: OutspeedSDK.Voice.david.rawValue)
 
                 let config = OutspeedSDK.SessionConfig(
                     overrides: OutspeedSDK.ConversationConfigOverride(


### PR DESCRIPTION
last time we made a change in SDK that allows it to be built on iOS 15+, instead of iOS 18. because of this, example voice bot stopped building, because it was using a contentTransition method which requires iOS 16+. i've also fixed that.